### PR TITLE
TweetinviAPI should only be linked from Twitter project

### DIFF
--- a/src/BioEngine.BRC.Web/BioEngine.BRC.Web.csproj
+++ b/src/BioEngine.BRC.Web/BioEngine.BRC.Web.csproj
@@ -13,6 +13,5 @@
     <PackageReference Include="cloudscribe.Syndication.Web" Version="3.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
     <PackageReference Include="cloudscribe.Web.SiteMap" Version="4.1.0" />
-    <PackageReference Include="TweetinviAPI" Version="4.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove TweetinviAPI dependency from BioEngine.BRC.Web project